### PR TITLE
✨ Multiple delegation targets

### DIFF
--- a/auto-delegate-annotations/src/main/java/com/ryandens/delegation/AutoDelegate.java
+++ b/auto-delegate-annotations/src/main/java/com/ryandens/delegation/AutoDelegate.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  * }
  * }</pre>
  *
- * This annotation strives to enable developers in the same fashion by generating abstract {@code
+ * <p>This annotation strives to enable developers in the same fashion by generating abstract {@code
  * Forwarding*} classes that delegate to the inner composed instance. An equivalent {@code
  * InstrumentedSet} implementation written with {@code AutoDelegate} is
  *
@@ -70,10 +70,15 @@ import java.lang.annotation.Target;
  * }
  * }</pre>
  *
- * While this is not as concise as the Kotlin implementation, it generates a class called {@code
+ * <p>While this is not as concise as the Kotlin implementation, it generates a class called {@code
  * AutoDelegate_InstrumentedSet} in the same package as the declaring class. The declared class can
  * then extend the generated class and call {code super} APIs where appropriate, only overriding
  * methods that are relevant to the implementation
+ *
+ * <p>In addition, this annotation supports targeting multiple interfaces for delegation rather than
+ * just one. This is useful when separating the responsibilities of a monolithic class into multiple
+ * separate classes with one responsibility, but still tying them all together via a single concrete
+ * instance.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)
@@ -83,6 +88,19 @@ public @interface AutoDelegate {
    * @return an interface that the generated class should delegate to via an inner composed
    *     instance. Note,the class annotated by this {@link AutoDelegate} element must be assignable
    *     from the class provided in this annotation.
+   * @throws IllegalArgumentException if this array is not {@link Void#getClass()} and {@link #to()}
+   *     is not empty, meaning only one of these values should be specified in a usage of this
+   *     annotation
    */
-  Class<?> value();
+  Class<?> value() default void.class;
+
+  /**
+   * @return the interfaces that the generated class should delegate to via inner composes
+   *     instances. Note, the class annotated by this {@link AutoDelegate} annotation must be
+   *     assignable from each of the classes provided with this annotation.
+   * @throws IllegalArgumentException if this array is not empty and {@link #value()} is not {@link
+   *     Void#getClass()}, meaning only one of these values should be specified in a usage of this *
+   *     annotation
+   */
+  Class<?>[] to() default {};
 }

--- a/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/Bar.java
+++ b/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/Bar.java
@@ -1,0 +1,9 @@
+package com.ryandens.delegation.examples;
+
+public interface Bar {
+  boolean a();
+
+  String b();
+
+  int c();
+}

--- a/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/Baz.java
+++ b/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/Baz.java
@@ -1,0 +1,8 @@
+package com.ryandens.delegation.examples;
+
+public interface Baz {
+
+  Object d();
+
+  long f();
+}

--- a/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/Foo.java
+++ b/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/Foo.java
@@ -1,0 +1,81 @@
+package com.ryandens.delegation.examples;
+
+import com.ryandens.delegation.AutoDelegate;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+
+/**
+ * Manages a thread-safe state {@link #hasBeenInvoked}. This first time {@link #a()} or {@link #d()}
+ * is invoked, this boolean is flipped from {@link State#NOT_INVOKED} to either {@link
+ * State#A_INVOKED} or {@link State#D_INVOKED}. If {@link #a()} is called first, every time {@link
+ * #d()} is called an {@link IllegalStateException} wll be thrown. The opposite is true if {@link
+ * #d()} is called first
+ *
+ * <p>Thread-safe
+ */
+@AutoDelegate(to = {Bar.class, Baz.class})
+public final class Foo extends AutoDelegate_Foo implements Bar, Baz {
+
+  private final AtomicReference<State> hasBeenInvoked;
+  private final StateUpdaterFunction aInvokedUpdaterFunction;
+  private final StateUpdaterFunction dInvokedUpdaterFunction;
+
+  enum State {
+    NOT_INVOKED,
+    A_INVOKED,
+    D_INVOKED
+  }
+
+  public Foo(final Bar bar, final Baz baz) {
+    super(bar, baz);
+    hasBeenInvoked = new AtomicReference<>(State.NOT_INVOKED);
+    aInvokedUpdaterFunction = new StateUpdaterFunction(State.A_INVOKED);
+    dInvokedUpdaterFunction = new StateUpdaterFunction(State.D_INVOKED);
+  }
+
+  @Override
+  public boolean a() {
+    final State previousValue = hasBeenInvoked.getAndUpdate(aInvokedUpdaterFunction);
+    if (State.NOT_INVOKED.equals(previousValue) || State.A_INVOKED.equals(previousValue)) {
+      return super.a();
+    } else {
+      throw new IllegalStateException("Can not call Foo.a() after a call to Foo.d()");
+    }
+  }
+
+  @Override
+  public Object d() {
+    final State previousValue = hasBeenInvoked.getAndUpdate(dInvokedUpdaterFunction);
+    if (State.NOT_INVOKED.equals(previousValue) || State.D_INVOKED.equals(previousValue)) {
+      return super.d();
+    } else {
+      throw new IllegalStateException("Can not call Foo.d() after a call to Foo.a()");
+    }
+  }
+
+  /**
+   * A {@link UnaryOperator} that consumes a previous {@link State} and returns the specified {@link
+   * #desiredNewState} if the previous state was either {@link State#NOT_INVOKED} or equal to the
+   * desired new state. Otherwise, the previous state is returned.
+   *
+   * <p>For example, if the desired state is A_INVOKED but the previous state was B_INVOKED,
+   * B_INVOKED will be returned so as to not change this value after being set by {@link
+   * AtomicReference#getAndUpdate(UnaryOperator)}
+   */
+  private static final class StateUpdaterFunction implements UnaryOperator<State> {
+    private final State desiredNewState;
+
+    private StateUpdaterFunction(final State desiredNewState) {
+      this.desiredNewState = desiredNewState;
+    }
+
+    @Override
+    public State apply(final State previousState) {
+      if (previousState.equals(State.NOT_INVOKED) || previousState.equals(desiredNewState)) {
+        return desiredNewState;
+      } else {
+        return previousState;
+      }
+    }
+  }
+}

--- a/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/FooTest.java
+++ b/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/FooTest.java
@@ -1,0 +1,80 @@
+package com.ryandens.delegation.examples;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link Foo} */
+final class FooTest {
+
+  private Foo foo;
+
+  @BeforeEach
+  void beforeEach() {
+    // GIVEN a valid foo instance
+    final var bar = mock(Bar.class);
+    final var baz = mock(Baz.class);
+    foo = new Foo(bar, baz);
+  }
+
+  /** Verifies that if we invoke {@link Foo#a()} */
+  @Test
+  void test_foo_a_invoked_first() {
+    // WHEN we invoke foo.a()
+    foo.a();
+    // VERIFY foo.d() now causes exception
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          foo.d();
+        });
+
+    // VERIFY foo.d() still causes an exception
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          foo.d();
+        });
+
+    // VERIFY we can still re-invoke foo.a()
+    foo.a();
+
+    // VERIFY foo.d() still causes an exception
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          foo.d();
+        });
+  }
+
+  /** TODO */
+  @Test
+  void test_foo_d_invoked_first() {
+    // WHEN we invoke foo.d()
+    foo.d();
+    // VERIFY foo.a() now causes exception
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          foo.a();
+        });
+
+    // VERIFY foo.a() still causes an exception
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          foo.a();
+        });
+
+    // VERIFY we can still re-invoke foo.d()
+    foo.d();
+    // VERIFY foo.a() still causes an exception
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          foo.a();
+        });
+  }
+}

--- a/auto-delegate-processor/src/main/java/com/ryandens/delegation/AutoDelegateProcessor.java
+++ b/auto-delegate-processor/src/main/java/com/ryandens/delegation/AutoDelegateProcessor.java
@@ -5,6 +5,11 @@ import static com.google.auto.common.AnnotationMirrors.getAnnotationValue;
 import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.auto.service.AutoService;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.processing.AbstractProcessor;
@@ -14,11 +19,13 @@ import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleAnnotationValueVisitor8;
@@ -57,38 +64,64 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
                           "element should always be annotated with AutoDelegate"));
       // From the AnnotationMirror, get the value of AutoDelegate#value and translate it
       // into an Element
-      final var apisToDelegate = getInterfaceToDelegateAsElement(annotationMirror);
+      final var valueToDelegateField = getInterfaceToDelegateAsElement(annotationMirror);
+      final var toDelegateSetField = getInterfacesToDelegateAsElementSet(annotationMirror);
+
+      if (valueToDelegateField == null && toDelegateSetField.isEmpty()) {
+        throw new IllegalArgumentException("A delegation target must be provided");
+      } else if (valueToDelegateField != null && !toDelegateSetField.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Only one mechanism of supplying delegation targets should be used");
+      }
+      final var apisToDelegate =
+          valueToDelegateField != null ? List.of(valueToDelegateField) : toDelegateSetField;
       // from the Element annotated with AutoDelegate, get their declared interfaces. Find the
       // interface that is also specified as the delegation target in AutoDelegate#value
-      final var type =
+
+      final var types =
           (((TypeElement) element)
               .getInterfaces().stream()
                   .map(typeMirror -> (DeclaredType) typeMirror)
-                  .filter(declaredType -> apisToDelegate.equals(declaredType.asElement()))
-                  .collect(
-                      Collectors.collectingAndThen(
-                          Collectors.toList(),
-                          list -> {
-                            if (list.size() == 0) {
-                              throw new IllegalArgumentException(
-                                  "No interfaces declared on the class match the element specified in AutoDelegate#value");
-                            } else if (list.size() > 1) {
-                              throw new IllegalStateException(
-                                  "Multiple interfaces declared on the class match the element specified in AutoDelegate#value");
-                            } else {
-                              return list.get(0);
-                            }
-                          })));
+                  .filter(declaredType -> apisToDelegate.contains(declaredType.asElement()))
+                  .collect(Collectors.toList()));
 
-      // From the type we are auto-delegating to find all abstract ExecutableElements defined on the
+      final var mutableDelegationTargetDescriptors = new LinkedList<DelegationTargetDescriptor>();
+      for (int i = 0; i < types.size(); i++) {
+        mutableDelegationTargetDescriptors.add(
+            new DelegationTargetDescriptor(types.get(i), "inner" + i));
+      }
+
+      if (types.size() == 0) {
+        throw new IllegalArgumentException(
+            "No interfaces declared on the class match the element specified in AutoDelegate#value");
+      }
+
+      final var delegationTargetDescriptors =
+          Collections.unmodifiableList(mutableDelegationTargetDescriptors);
+
+      // From each type we are auto-delegating to find all abstract ExecutableElements defined on
+      // the
       // interface and collect them into a set of ExecutableElements
-      final var memberElements =
-          elementUtils.getAllMembers((TypeElement) type.asElement()).stream()
-              .filter(
-                  typeElementMember -> typeElementMember.getModifiers().contains(Modifier.ABSTRACT))
-              .filter(typeElementMember -> typeElementMember instanceof ExecutableElement)
-              .map(typeElementMember -> (ExecutableElement) typeElementMember)
-              .collect(Collectors.toSet());
+      final var memberElementsMap =
+          delegationTargetDescriptors.stream()
+              .map(
+                  delegationTargetDescriptor ->
+                      new AbstractMap.SimpleEntry<>(
+                          delegationTargetDescriptor,
+                          elementUtils
+                              .getAllMembers(
+                                  (TypeElement)
+                                      delegationTargetDescriptor.declaredType().asElement())
+                              .stream()
+                              .filter(
+                                  typeElementMember ->
+                                      typeElementMember.getModifiers().contains(Modifier.ABSTRACT))
+                              .filter(
+                                  typeElementMember ->
+                                      typeElementMember instanceof ExecutableElement)
+                              .map(typeElementMember -> (ExecutableElement) typeElementMember)
+                              .collect(Collectors.toSet())))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
       // Get the package of the element annotated with AutoDelegate, as the
       final var destinationPackageName =
           MoreElements.getPackage(element).getQualifiedName().toString();
@@ -96,8 +129,8 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
               filer,
               destinationPackageName,
               "AutoDelegate_" + element.getSimpleName(),
-              memberElements,
-              type)
+              delegationTargetDescriptors,
+              memberElementsMap)
           .write();
     }
     return false;
@@ -120,7 +153,36 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
             new SimpleAnnotationValueVisitor8<Element, Void>() {
               @Override
               public Element visitType(TypeMirror typeMirror, Void v) {
-                return MoreTypes.asDeclared(typeMirror).asElement();
+                if (typeMirror.getKind().equals(TypeKind.VOID)) {
+                  return null;
+                } else {
+                  return MoreTypes.asDeclared(typeMirror).asElement();
+                }
+              }
+            },
+            null);
+  }
+
+  /** Returns the contents of {@link AutoDelegate#value()} as an {@link Element} */
+  private List<Element> getInterfacesToDelegateAsElementSet(AnnotationMirror annotationMirror) {
+    return getAnnotationValue(annotationMirror, "to")
+        .accept(
+            new SimpleAnnotationValueVisitor8<List<Element>, Void>() {
+              @Override
+              public List<Element> visitType(TypeMirror typeMirror, Void v) {
+                if (typeMirror.getKind().equals(TypeKind.VOID)) {
+                  return null;
+                } else {
+                  return List.of(MoreTypes.asDeclared(typeMirror).asElement());
+                }
+              }
+
+              @Override
+              public List<Element> visitArray(
+                  final List<? extends AnnotationValue> values, final Void unused) {
+                return values.stream()
+                    .flatMap(value -> value.accept(this, null).stream())
+                    .collect(Collectors.toList());
               }
             },
             null);

--- a/auto-delegate-processor/src/main/java/com/ryandens/delegation/DelegationTargetDescriptor.java
+++ b/auto-delegate-processor/src/main/java/com/ryandens/delegation/DelegationTargetDescriptor.java
@@ -1,0 +1,23 @@
+package com.ryandens.delegation;
+
+import javax.lang.model.type.DeclaredType;
+
+/** Immutable value class encapsulating all the information about an inner type to delegate to */
+final class DelegationTargetDescriptor {
+
+  private final DeclaredType declaredType;
+  private final String fieldName;
+
+  DelegationTargetDescriptor(final DeclaredType declaredType, final String fieldName) {
+    this.declaredType = declaredType;
+    this.fieldName = fieldName;
+  }
+
+  DeclaredType declaredType() {
+    return declaredType;
+  }
+
+  String fieldName() {
+    return fieldName;
+  }
+}


### PR DESCRIPTION
Allow the `AutoDelegate` annotation to delegate to multiple targets via the `Class<?>[] to()` API. In addition, some refactors as I learn more about how this tool will change and be extended in the future. 