### PR TITLE
Gradle Platform for auto-delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Requirements:
 
 ```kotlin
 dependencies {
-    compileOnly("com.ryandens", "auto-delegate-annotations", "0.2.0")
-    annotationProcessor("com.ryandens", "auto-delegate-processor", "0.2.0")
+    implementation(platform("com.ryandens:auto-delegate-platform:0.2.0"))
+    compileOnly("com.ryandens", "auto-delegate-annotations")
+    annotationProcessor("com.ryandens", "auto-delegate-processor")
 }
 ```
 

--- a/auto-delegate-platform/build.gradle.kts
+++ b/auto-delegate-platform/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    `java-platform`
+    id("com.ryandens.delegation.publish")
+}
+
+description = """
+    A Gradle platform, published as a Gradle Module Metadata and a Maven BOM, to help projects consume compatible versions of dependencies published by this project
+""".trimIndent()
+
+publishing {
+    publications {
+        named<MavenPublication>("nebula") {
+            from(components["javaPlatform"])
+        }
+    }
+}
+
+dependencies {
+    constraints {
+        api("${project.group}:${project(":auto-delegate-annotations").name}:${project.version}")
+        runtime("${project.group}:${project(":auto-delegate-processor").name}:${project.version}")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,12 @@ nexusPublishing {
 }
 
 subprojects {
-    spotless {
-        // all subprojects must apply the java plugin
-        java {
-            googleJavaFormat("1.9")
+    if (project.plugins.hasPlugin(JavaPlugin::class.java)) {
+        spotless {
+            // all subprojects must apply the java plugin
+            java {
+                googleJavaFormat("1.9")
+            }
         }
     }
     group = "com.ryandens"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,4 +8,9 @@
  */
 
 rootProject.name = "auto-delegate"
-include("auto-delegate-annotations", "auto-delegate-processor", "auto-delegate-examples")
+include(
+    "auto-delegate-annotations",
+    "auto-delegate-examples",
+    "auto-delegate-platform",
+    "auto-delegate-processor"
+)


### PR DESCRIPTION
Creates a Gradle Platform as both a Gradle Module Metadata file and a Maven BOM. See [Java Platform Plugin](https://docs.gradle.org/current/userguide/java_platform_plugin.html) for details

I was curious about this plugin and used this as an opportunity to learn more. I'm open this PR and leaving it for now, because I'm not sure if it's detrimental to this project, and wanted to have more time to think about it.

Technically, the value here is just that what was previously

```kotlin
val autoDelegateVersion = "0.2.0"
compileOnly("com.ryandens", "auto-delegate-annotations", autoDelegateVersion)
annotationProcessor("com.ryandens", "auto-delegate-processor", autoDelegateVersion)
```

is now 
```kotlin
implementation(platform("com.ryandens:auto-delegate-platform:0.2.0"))
compileOnly("com.ryandens", "auto-delegate-annotations")
annotationProcessor("com.ryandens", "auto-delegate-processor")
```

This seems like something that tends to be more helpful that has many modules, and I find it unlikely that this project will deviate from the well-established practice of modularization for annotation processors where one artifact is published with annotations and another with the annotation processor. 