### PR TITLE
:sparkles: Add support for delegating to default APIs

### DIFF
--- a/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/Baz.java
+++ b/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/Baz.java
@@ -5,4 +5,8 @@ public interface Baz {
   Object d();
 
   long f();
+
+  default String g() {
+    return "g";
+  }
 }

--- a/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/FooTest.java
+++ b/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/FooTest.java
@@ -1,7 +1,10 @@
 package com.ryandens.delegation.examples;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,13 +13,14 @@ import org.junit.jupiter.api.Test;
 final class FooTest {
 
   private Foo foo;
+  private Baz innerComposedBaz;
 
   @BeforeEach
   void beforeEach() {
     // GIVEN a valid foo instance
     final var bar = mock(Bar.class);
-    final var baz = mock(Baz.class);
-    foo = new Foo(bar, baz);
+    innerComposedBaz = mock(Baz.class);
+    foo = new Foo(bar, innerComposedBaz);
   }
 
   /** Verifies that if we invoke {@link Foo#a()} */
@@ -76,5 +80,14 @@ final class FooTest {
         () -> {
           foo.a();
         });
+
+    // WHEN we invoke foo.g(), which has a default implementation defined on the interface Baz
+    final String g = foo.g();
+    // VERIFY the composed instance baz was delegated to, not the default implementation of the API
+    // inherited by Foo
+    verify(innerComposedBaz, times(1)).g();
+    // VERIFY g is null, what the mock implementation of Baz.g returns, rather than the string "g"
+    // what the default implementation of Baz.g returns
+    assertNull(g);
   }
 }

--- a/auto-delegate-processor/src/main/java/com/ryandens/delegation/AutoDelegateGenerator.java
+++ b/auto-delegate-processor/src/main/java/com/ryandens/delegation/AutoDelegateGenerator.java
@@ -74,7 +74,10 @@ final class AutoDelegateGenerator {
                             // auto-delegating to
                             .filter(
                                 typeElementMember ->
-                                    typeElementMember.getModifiers().contains(Modifier.ABSTRACT))
+                                    typeElementMember.getModifiers().contains(Modifier.ABSTRACT)
+                                        || typeElementMember
+                                            .getModifiers()
+                                            .contains(Modifier.DEFAULT))
                             // then, collect it into a Set<ExecutableElement> that the key
                             // DelegationTargetDescriptor should delegate to
                             .collect(Collectors.toSet())))

--- a/auto-delegate-processor/src/main/java/com/ryandens/delegation/AutoDelegateProcessor.java
+++ b/auto-delegate-processor/src/main/java/com/ryandens/delegation/AutoDelegateProcessor.java
@@ -27,6 +27,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleAnnotationValueVisitor8;
+import javax.lang.model.util.Types;
 
 /**
  * Annotation processor that generates abstract classes that delegate to an inner composed
@@ -37,10 +38,12 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
 
   private Filer filer;
   private Elements elementUtils;
+  private Types typeUtils;
 
   @Override
   public void init(final ProcessingEnvironment processingEnv) {
     filer = processingEnv.getFiler();
+    typeUtils = processingEnv.getTypeUtils();
     elementUtils = processingEnv.getElementUtils();
   }
 
@@ -126,7 +129,11 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
       final var className = "AutoDelegate_" + element.getSimpleName();
       final var javaFile =
           new AutoDelegateGenerator(
-                  elementUtils, destinationPackageName, className, delegationTargetDescriptors)
+                  elementUtils,
+                  typeUtils,
+                  destinationPackageName,
+                  className,
+                  delegationTargetDescriptors)
               .autoDelegate();
       try {
         // Write the JavaFile to the local environment

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ subprojects {
         }
     }
     group = "com.ryandens"
-    version = "0.2.1"
+    version = "0.2.2"
 
     this.extensions.getByType<nebula.plugin.contacts.ContactsExtension>().run {
         addPerson("admin@ryandens.com", delegateClosureOf<nebula.plugin.contacts.Contact> {


### PR DESCRIPTION
- The "Feature" part of this was quite simple, in that we simply generate a delegating method spec for each API on the type we're delegating to for default methods in addition to abstract methods.
- This feature exposed an existing bug in our generation of method specs for interfaces with type parameters used with different names in multiple hierarchies. We instead choose to use an API for generating the overriding method stub that picks the right type parameter name for parameters automatically. This gets us one step closer to not having to share type parameter names with the delegation target! :tada: