### PR TITLE
✨ Support Partial Delegation

### DIFF
--- a/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/PartialDelegationExample.java
+++ b/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/PartialDelegationExample.java
@@ -1,0 +1,30 @@
+package com.ryandens.delegation.examples;
+
+import com.ryandens.delegation.AutoDelegate;
+
+/** Base interface. */
+interface Base {
+  String foo();
+}
+
+/** Extension of {@link Base}. */
+interface Extension extends Base {
+  String bar();
+}
+
+/**
+ * Implementation of {@link Extension} that delegates methods from {@link Base} to some other
+ * instance.
+ */
+@AutoDelegate(Base.class)
+class ExtensionImpl extends AutoDelegate_ExtensionImpl implements Extension {
+
+  ExtensionImpl(final Base delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public String bar() {
+    return "bar";
+  }
+}

--- a/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/PartialDelegationExampleTest.java
+++ b/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/PartialDelegationExampleTest.java
@@ -1,0 +1,22 @@
+package com.ryandens.delegation.examples;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/** Test that verifies that the partial delegation example works as expected. */
+final class PartialDelegationExampleTest {
+
+  @Test
+  void partial_delegation() {
+    final var delegate =
+        new Base() {
+          @Override
+          public String foo() {
+            return "foo";
+          }
+        };
+    final var extension = new ExtensionImpl(delegate);
+    assertEquals("bar", extension.bar());
+  }
+}


### PR DESCRIPTION
Considers direct super types when checking that the annotated type implements the interface to delegate to. This allows a type to delegate only those methods declared by an interface type's super type. See `PartialDelegationExample`.