### PR TITLE
ryandens/update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoDelegate
 
-![Build](https://github.com/ryandens/auto-delegate/workflows/Build/badge.svg?branch=main)
+![Build](https://github.com/ryandens/auto-delegate/workflows/Validate/badge.svg?branch=main)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.ryandens/auto-delegate-annotations/badge.svg#)](https://maven-badges.herokuapp.com/maven-central/com.ryandens/auto-delegate-annotations)
 
 Java annotation processor for automatically delegating interface APIs to a composed instance of that interface. This
@@ -167,11 +167,12 @@ APIs where appropriate, only overriding methods that are relevant to the impleme
 
 ### 👩‍💻 Development Requirements
 
-- JDK 16
+- JDK 17
 
 ### 🚀 Releasing
 
 1. Make sure the `sonatypeUsername` and `sonatypePassword` properties are set.
+1. Make sure the `signing.keyId`, `signing.password`, and `signing.secretKeyRingFile` properties are set.
 1. `./gradlew build signNebulaPublication publishNebulaPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository`
 
 Note, the `stagingProfileId` set in the root `build.gradle.kts` was retrieved using the `getStagingProfile` diagnostic

--- a/auto-delegate-examples/build.gradle.kts
+++ b/auto-delegate-examples/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 tasks.compileJava {
-    options.release.set(16)
+    options.release.set(17)
 }
 
 dependencies {

--- a/auto-delegate-processor/build.gradle.kts
+++ b/auto-delegate-processor/build.gradle.kts
@@ -15,7 +15,7 @@ tasks.compileJava {
 }
 
 tasks.compileTestJava {
-    options.release.set(16)
+    options.release.set(17)
 }
 
 tasks {


### PR DESCRIPTION
- :pencil: update docs to reflect use of JDK 17 for building, required GPG properties, and update badge
- :recycle: use java 17 for examples
