### PR TITLE
Support multiple generic template values

### DIFF
--- a/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/InstrumentedMap.java
+++ b/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/InstrumentedMap.java
@@ -1,0 +1,30 @@
+package com.ryandens.delegation.examples;
+
+import java.util.Map;
+
+import com.ryandens.delegation.AutoDelegate;
+
+@AutoDelegate(Map.class)
+public final class InstrumentedMap<K, V> extends AutoDelegate_InstrumentedMap<K, V> implements Map<K, V> {
+    private int putCount;
+
+    InstrumentedMap(final Map<K, V> inner0) {
+        super(inner0);
+    }
+
+    @Override
+    public V put(final K k, final V v) {
+        putCount++;
+        return super.put(k, v);
+    }
+
+    @Override
+    public void putAll(final Map<? extends K, ? extends V> m) {
+        putCount += m.size();
+        super.putAll(m);
+    }
+
+    public int putCount() {
+        return putCount;
+    }
+}

--- a/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/InstrumentedMap.java
+++ b/auto-delegate-examples/src/main/java/com/ryandens/delegation/examples/InstrumentedMap.java
@@ -1,30 +1,30 @@
 package com.ryandens.delegation.examples;
 
+import com.ryandens.delegation.AutoDelegate;
 import java.util.Map;
 
-import com.ryandens.delegation.AutoDelegate;
-
 @AutoDelegate(Map.class)
-public final class InstrumentedMap<K, V> extends AutoDelegate_InstrumentedMap<K, V> implements Map<K, V> {
-    private int putCount;
+public final class InstrumentedMap<K, V> extends AutoDelegate_InstrumentedMap<K, V>
+    implements Map<K, V> {
+  private int putCount;
 
-    InstrumentedMap(final Map<K, V> inner0) {
-        super(inner0);
-    }
+  InstrumentedMap(final Map<K, V> inner0) {
+    super(inner0);
+  }
 
-    @Override
-    public V put(final K k, final V v) {
-        putCount++;
-        return super.put(k, v);
-    }
+  @Override
+  public V put(final K k, final V v) {
+    putCount++;
+    return super.put(k, v);
+  }
 
-    @Override
-    public void putAll(final Map<? extends K, ? extends V> m) {
-        putCount += m.size();
-        super.putAll(m);
-    }
+  @Override
+  public void putAll(final Map<? extends K, ? extends V> m) {
+    putCount += m.size();
+    super.putAll(m);
+  }
 
-    public int putCount() {
-        return putCount;
-    }
+  public int putCount() {
+    return putCount;
+  }
 }

--- a/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/InstrumentedMapTest.java
+++ b/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/InstrumentedMapTest.java
@@ -1,57 +1,52 @@
 package com.ryandens.delegation.examples;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 class InstrumentedMapTest {
-    private InstrumentedMap<String, String> instrumentedMap;
+  private InstrumentedMap<String, String> instrumentedMap;
 
-    @BeforeEach
-    void beforeEach() {
-        // GIVEN an instrumented Map<String>
-        instrumentedMap = new InstrumentedMap<>(new HashMap<>());
-    }
+  @BeforeEach
+  void beforeEach() {
+    // GIVEN an instrumented Map<String>
+    instrumentedMap = new InstrumentedMap<>(new HashMap<>());
+  }
 
-    @Test
-    void testInitialPutCount() {
-        // VERIFY initial putCount is 0
-        assertEquals(0, instrumentedMap.putCount());
-    }
+  @Test
+  void testInitialPutCount() {
+    // VERIFY initial putCount is 0
+    assertEquals(0, instrumentedMap.putCount());
+  }
 
-    /**
-     * Tests that the {@link InstrumentedMap#put} implementation functions properly
-     */
-    @Test
-    void testPut() {
-        // WHEN we add an element to the Map
-        instrumentedMap.put("foo", "!");
-        // VERIFY the putCount is now 1
-        assertEquals(1, instrumentedMap.putCount());
-        // WHEN we add an element to the Map again
-        instrumentedMap.put("bar", "!!");
-        // VERIFY the putCount is now 2
-        assertEquals(2, instrumentedMap.putCount());
-        // WHEN we add an element to the Map again that is already in the Map
-        instrumentedMap.put("foo", "!!!");
-        // VERIFY the putCount is now 3
-        assertEquals(3, instrumentedMap.putCount());
-        // VERIFY size is 2
-        assertEquals(2, instrumentedMap.size());
-    }
+  /** Tests that the {@link InstrumentedMap#put} implementation functions properly */
+  @Test
+  void testPut() {
+    // WHEN we add an element to the Map
+    instrumentedMap.put("foo", "!");
+    // VERIFY the putCount is now 1
+    assertEquals(1, instrumentedMap.putCount());
+    // WHEN we add an element to the Map again
+    instrumentedMap.put("bar", "!!");
+    // VERIFY the putCount is now 2
+    assertEquals(2, instrumentedMap.putCount());
+    // WHEN we add an element to the Map again that is already in the Map
+    instrumentedMap.put("foo", "!!!");
+    // VERIFY the putCount is now 3
+    assertEquals(3, instrumentedMap.putCount());
+    // VERIFY size is 2
+    assertEquals(2, instrumentedMap.size());
+  }
 
-    /**
-     * Tests that the {@link InstrumentedMap#putAll} implementation functions properly
-     */
-    @Test
-    void testPutALl() {
-        // WHEN we use putAll to add two elements to the Map
-        instrumentedMap.putAll(Map.of("k1", "v1", "k2", "v2"));
-        // VERIFY the putCount is now 2
-        assertEquals(2, instrumentedMap.putCount());
-    }
+  /** Tests that the {@link InstrumentedMap#putAll} implementation functions properly */
+  @Test
+  void testPutALl() {
+    // WHEN we use putAll to add two elements to the Map
+    instrumentedMap.putAll(Map.of("k1", "v1", "k2", "v2"));
+    // VERIFY the putCount is now 2
+    assertEquals(2, instrumentedMap.putCount());
+  }
 }

--- a/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/InstrumentedMapTest.java
+++ b/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/InstrumentedMapTest.java
@@ -13,45 +13,45 @@ class InstrumentedMapTest {
 
     @BeforeEach
     void beforeEach() {
-        // GIVEN an instrumented Set<String>
+        // GIVEN an instrumented Map<String>
         instrumentedMap = new InstrumentedMap<>(new HashMap<>());
     }
 
     @Test
-    void testInitialAddCount() {
-        // VERIFY initial addCount is 0
+    void testInitialPutCount() {
+        // VERIFY initial putCount is 0
         assertEquals(0, instrumentedMap.putCount());
     }
 
     /**
-     * Tests that the {@link InstrumentedSet#add} implementation functions properly
+     * Tests that the {@link InstrumentedMap#put} implementation functions properly
      */
     @Test
     void testPut() {
-        // WHEN we add an element to the Set
+        // WHEN we add an element to the Map
         instrumentedMap.put("foo", "!");
-        // VERIFY the addCount is now 1
+        // VERIFY the putCount is now 1
         assertEquals(1, instrumentedMap.putCount());
-        // WHEN we add an element to the Set again
+        // WHEN we add an element to the Map again
         instrumentedMap.put("bar", "!!");
-        // VERIFY the addCount is now 2
+        // VERIFY the putCount is now 2
         assertEquals(2, instrumentedMap.putCount());
-        // WHEN we add an element to the Set again that is already in the Set
+        // WHEN we add an element to the Map again that is already in the Map
         instrumentedMap.put("foo", "!!!");
-        // VERIFY the addCount is now 3
+        // VERIFY the putCount is now 3
         assertEquals(3, instrumentedMap.putCount());
         // VERIFY size is 2
         assertEquals(2, instrumentedMap.size());
     }
 
     /**
-     * Tests that the {@link InstrumentedSet#addAll} implementation functions properly
+     * Tests that the {@link InstrumentedMap#putAll} implementation functions properly
      */
     @Test
     void testPutALl() {
-        // WHEN we use addAll to add two elements to the Set
+        // WHEN we use putAll to add two elements to the Map
         instrumentedMap.putAll(Map.of("k1", "v1", "k2", "v2"));
-        // VERIFY the addCount is now 2
+        // VERIFY the putCount is now 2
         assertEquals(2, instrumentedMap.putCount());
     }
 }

--- a/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/InstrumentedMapTest.java
+++ b/auto-delegate-examples/src/test/java/com/ryandens/delegation/examples/InstrumentedMapTest.java
@@ -1,0 +1,57 @@
+package com.ryandens.delegation.examples;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InstrumentedMapTest {
+    private InstrumentedMap<String, String> instrumentedMap;
+
+    @BeforeEach
+    void beforeEach() {
+        // GIVEN an instrumented Set<String>
+        instrumentedMap = new InstrumentedMap<>(new HashMap<>());
+    }
+
+    @Test
+    void testInitialAddCount() {
+        // VERIFY initial addCount is 0
+        assertEquals(0, instrumentedMap.putCount());
+    }
+
+    /**
+     * Tests that the {@link InstrumentedSet#add} implementation functions properly
+     */
+    @Test
+    void testPut() {
+        // WHEN we add an element to the Set
+        instrumentedMap.put("foo", "!");
+        // VERIFY the addCount is now 1
+        assertEquals(1, instrumentedMap.putCount());
+        // WHEN we add an element to the Set again
+        instrumentedMap.put("bar", "!!");
+        // VERIFY the addCount is now 2
+        assertEquals(2, instrumentedMap.putCount());
+        // WHEN we add an element to the Set again that is already in the Set
+        instrumentedMap.put("foo", "!!!");
+        // VERIFY the addCount is now 3
+        assertEquals(3, instrumentedMap.putCount());
+        // VERIFY size is 2
+        assertEquals(2, instrumentedMap.size());
+    }
+
+    /**
+     * Tests that the {@link InstrumentedSet#addAll} implementation functions properly
+     */
+    @Test
+    void testPutALl() {
+        // WHEN we use addAll to add two elements to the Set
+        instrumentedMap.putAll(Map.of("k1", "v1", "k2", "v2"));
+        // VERIFY the addCount is now 2
+        assertEquals(2, instrumentedMap.putCount());
+    }
+}

--- a/auto-delegate-processor/src/main/java/com/ryandens/delegation/AutoDelegateGenerator.java
+++ b/auto-delegate-processor/src/main/java/com/ryandens/delegation/AutoDelegateGenerator.java
@@ -99,7 +99,7 @@ final class AutoDelegateGenerator {
       final var typeVariables =
           MoreTypes.asTypeElement(descriptor.declaredType()).getTypeParameters().stream()
               .map(TypeVariableName::get)
-              .collect(Collectors.toSet());
+              .collect(Collectors.toUnmodifiableList());
       typeSpecBuilder.addTypeVariables(typeVariables);
 
       //  implement the specified interface for this delegation target


### PR DESCRIPTION
I noticed that when generating code sometimes it would mix up the order of the types:

Map<K, V> would generate AutoDelegate_DelegatingMap<V, K>

The main change is switching template types to list, matching the original order, instead of a set.

Edit: Also, I think the set (as-is) would break if we put Map<String, String> ?