### PR TITLE
Add TestLens setup step to Validate workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,5 +23,8 @@ jobs:
         with:
           dependency-graph: generate-and-submit
 
+      - name: Setup TestLens
+        uses: testlens-app/setup-testlens@v1
+
       - name: Execute Gradle build
         run: ./gradlew build


### PR DESCRIPTION
Sets up the [TestLens GitHub Action](https://github.com/testlens-app/setup-testlens) in the `Validate` workflow, now that the TestLens GitHub App is installed on the repo.

## Change
Adds a `testlens-app/setup-testlens@v1` step between `Setup Gradle` and `Execute Gradle build`. Per the action's docs, for Gradle projects it writes an init script that instruments all `Test` tasks — so it must run after `setup-gradle` and before the `./gradlew build` invocation.

No inputs, secrets, or permission changes are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TestLens setup step to the Validate CI workflow
> Adds a `testlens-app/setup-testlens@v1` action step in [gradle.yml](.github/workflows/gradle.yml) that runs before the Gradle build execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a96143f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->